### PR TITLE
chore: use yarn cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - node
-cache: npm
+cache: yarn
 before_install:
 - openssl aes-256-cbc -K $encrypted_fbdbd197bbf4_key -iv $encrypted_fbdbd197bbf4_iv
   -in service-account.json.enc -out service-account.json -d


### PR DESCRIPTION
yarn is used on Travis builds and the cache setting is currently not correct as it doe snot load any cache.